### PR TITLE
remove unused and redundant platformio.ini config

### DIFF
--- a/RP23V50firmware/platformio.ini
+++ b/RP23V50firmware/platformio.ini
@@ -14,14 +14,10 @@ framework = arduino
 board_build.core = earlephilhower
 board_build.filesystem_size = 1.5m
 build_type = debug
-; Enable deep+ mode for better library dependency resolution
-; lib_ldf_mode = deep+
 upload_port = /dev/cu.usbmodem1101
 ; monitor_port = /dev/cu.usbmodem1101
 debug_init_break = no
 build_flags = -Iinclude/
-	; Ensure Arduino framework compatibility
-	-DARDUINO_ARCH_RP2040
 	-DUSE_TINYUSB
 	-DCFG_TUSB_CONFIG_FILE=\"custom_tusb_config.h\"
 	-DCFG_TUD_DESC_AUTO=0


### PR DESCRIPTION
- -DARDUINO_ARCH_RP2040 is already set in the platform config: https://github.com/maxgerhardt/platform-raspberrypi/blob/develop/boards/jumperless_v5.json
- Remove commented out dependency config